### PR TITLE
Fix rubocop-specs.yml file and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To use the different set of rules for spec files, add an additional `.rubocop.ym
 
 ```yaml
 inherit_from:
+  - ../.rubocop.yml
   - https://raw.githubusercontent.com/qmee/dev-public-utils/main/styleguides/rubocop-specs.yml
 ```
 

--- a/styleguides/rubocop-specs.yml
+++ b/styleguides/rubocop-specs.yml
@@ -1,7 +1,3 @@
-inherit_from:
-  - https://raw.githubusercontent.com/qmee/dev-public-utils/main/styleguides/rubocop.yml
-  - ../.rubocop.yml
-
 Metrics/BlockLength:
   Enabled: false
 

--- a/styleguides/rubocop-specs.yml
+++ b/styleguides/rubocop-specs.yml
@@ -1,3 +1,6 @@
+inherit_from:
+  - https://raw.githubusercontent.com/qmee/dev-public-utils/main/styleguides/rubocop.yml
+
 Metrics/BlockLength:
   Enabled: false
 


### PR DESCRIPTION
Inheriting from `../.rubocop.yml` in `rubocop-specs.yml` causes an error, because it will look for the file in this repo rather than on your machine.

I have also removed the main rubocop inheritance from the specs file because it would have called the main `.yml` file twice - the first time from the specs file, and the second time from the local file. With these changes, the rules will cascade as follows:

`dev-public-utils rubocop.yml` -> `local overrides` -> `spec-only rules` -> `spec-only overrides`

This means that local overrides won't be overwritten except for where the spec needs to change something.